### PR TITLE
Activate with word selection

### DIFF
--- a/findJump/README.md
+++ b/findJump/README.md
@@ -27,6 +27,7 @@ Find-Jump adds these commands:
 
 * `findJump.activate`: which activates Find-Jump
 * `findJump.activateWithSelection`: like `findJump.activate` but will make a selection from the current cursor position to the new cursor position
+* `findJump.activateWithWordSelection`: activates Find-Jump and selects the word at the new cursor position
 
 **Note** No keybinding is provided by this extension. You have to create one yourself.
 

--- a/findJump/package.json
+++ b/findJump/package.json
@@ -12,7 +12,11 @@
     "url": "https://github.com/msafi/xvsc/tree/master/findJump"
   },
   "categories": ["Other"],
-  "activationEvents": ["onCommand:findJump.activate", "onCommand:findJump.activateWithSelection"],
+  "activationEvents": [
+    "onCommand:findJump.activate",
+    "onCommand:findJump.activateWithSelection",
+    "onCommand:findJump.activateWithWordSelection"
+  ],
   "main": "./out/src/extension",
   "contributes": {
     "commands": [
@@ -23,7 +27,11 @@
       {
         "command": "findJump.activateWithSelection",
         "title": "Activate Find-Jump in selection mode"
-      }
+      },
+			{
+				"command": "findJump.activateWithWordSelection",
+				"title": "Activate Find-Jump in word selection mode"
+			}
     ]
   },
   "scripts": {

--- a/findJump/src/extension.ts
+++ b/findJump/src/extension.ts
@@ -15,6 +15,10 @@ export function activate(context: ExtensionContext) {
       'findJump.activateWithSelection',
       findJump.activateWithSelection,
     ),
+    commands.registerTextEditorCommand(
+      'findJump.activateWithWordSelection',
+      findJump.activateWithWordSelection,
+    ),
   )
 }
 


### PR DESCRIPTION
This PR adds a new command so a word can be selected with FindJump.

I noticed I would often FindJump to the beginning of a word then use a second shortcut to select the word. With this change you can jump to anywhere within a word (not just the beginning) and the whole word will then be automatically selected.